### PR TITLE
Update smoke test to reflect a change in the admin portal

### DIFF
--- a/spec/system/admin/team_page_spec.rb
+++ b/spec/system/admin/team_page_spec.rb
@@ -22,7 +22,7 @@ feature "Team Page" do
     it "removes a team member" do
       within(".leftnav") { click_link "Team members" }
 
-      find(:xpath, "//*[contains(text(), '#{test_email}')]/ancestor::dd/descendant::a[contains(text(), 'Edit permissions')]").click
+      find(:xpath, "//*[contains(text(), '#{test_email}')]/ancestor::dd/descendant::a[contains(text(), 'Edit')]").click
       click_link "Remove user from GovWifi admin"
       click_button "Yes, remove this team member"
 


### PR DESCRIPTION
The Team membership page had a link changed from "Edit Permissions" to "Edit"

