### PR TITLE
GW-2233: Optimise running time smoke tests

### DIFF
--- a/spec/support/remove_user_helper.rb
+++ b/spec/support/remove_user_helper.rb
@@ -10,6 +10,5 @@ module RemoveUserHelper
       click_link "Remove user"
       click_button "Remove user"
     end
-    logout
   end
 end

--- a/spec/system/signup/email_journey_spec.rb
+++ b/spec/system/signup/email_journey_spec.rb
@@ -18,7 +18,6 @@ feature "Email Journey" do
     fill_in "Username, email address or phone number", with: from_address
     click_button "Find user details"
     expect(page).to have_content("Nothing found")
-    logout
   end
   it "signs up successfully" do
     query = "from:#{notify_address} subject:Welcome is:unread to:#{from_address}"

--- a/spec/system/signup/sponsor_journey_spec.rb
+++ b/spec/system/signup/sponsor_journey_spec.rb
@@ -41,7 +41,6 @@ feature "Sponsor Journey" do
       fill_in "Username, email address or phone number", with: @sponsored_sms_number
       click_button "Find user details"
       expect(page).to have_content("Nothing found")
-      logout
     end
     it "has set the 'read' flag on all relevant emails" do
       expect(read_email(query: @sponsored_query)).to be_nil


### PR DESCRIPTION
### What
2FA token refreshes every 30 seconds, therefore `logout` action requires a sleep time of 30 seconds for the next `login` attempt

### Why
By reducing the `logout` action call, smoke tests run time reduced from 8 min to 4 mins 

### Link to JIRA card (if applicable): 
[GW-2233](https://technologyprogramme.atlassian.net/browse/GW-2233)
