### PR TITLE
fix: [GW-2439] filter sms messages

### DIFF
--- a/lib/notify_sms.rb
+++ b/lib/notify_sms.rb
@@ -10,7 +10,7 @@ module NotifySms
   def read_reply_sms(phone_number:, after_id:, timeout: 600, interval: 5)
     Timeout.timeout(timeout, nil, "Waited too long for signup SMS. Last received SMS is #{after_id}") do
       normalised_phone_number = normalise(phone_number:)
-      while (result = get_first_sms(phone_number: normalised_phone_number))&.id == after_id
+      while (result = get_signup_sms(phone_number: normalised_phone_number))&.id == after_id
         print "."
         sleep interval
       end
@@ -18,8 +18,25 @@ module NotifySms
     end
   end
 
+  ## This helper method is used to get the first SMS received from a given phone number.
+  ## however, it does not filter based on content.
   def get_first_sms(phone_number:)
     Services.notify.get_received_texts.collection.find { |message| message.user_number == normalise(phone_number:) }
+  end
+
+  # This helper method is used to get the signup SMS message sent to a given phone number.
+  # Find the first message that:
+  # 1. Has the correct phone number.
+  # 2. Contains the target text.
+  def get_signup_sms(phone_number:)
+    target_text = "Windows, Apple, and Chromebook users:" ## first line of SMS template
+    normalised_phone_number = normalise(phone_number:)
+
+    messages = Services.notify.get_received_texts.collection
+    messages.find do |message|
+      message.user_number == normalised_phone_number &&
+      message.content.include?(target_text)
+    end
   end
 
   def parse_sms_message(message:)


### PR DESCRIPTION
### What
Filter SMS messages so that only sign up sms are returned

### Why
Because the smoke tests would fail is the "account has been deleted" message was received instead of the sign up message.

### Note
Please have a good check of the Ruby, as AI was used to help form this method, which I have refined with my limited Ruby knowledge.

### Link to JIRA card (if applicable): 
[GW-2439](https://technologyprogramme.atlassian.net/browse/GW-2439)
